### PR TITLE
fix: Fix Reissue

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -25,7 +25,7 @@ let project = Project(
             infoPlist: .extendingDefault(
                 with: [
                     "CFBundleDisplayName": "도담도담",
-                    "CFBundleShortVersionString": "3.0.1",
+                    "CFBundleShortVersionString": "3.0.2",
                     "CFBundleVersion": "1",
                     "UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait"],
                     "UIMainStoryboardFile": "",

--- a/Projects/App/Source/Data/Network/Remote/RemoteInterceptor.swift
+++ b/Projects/App/Source/Data/Network/Remote/RemoteInterceptor.swift
@@ -23,15 +23,12 @@ class RemoteInterceptor: RequestInterceptor {
         }
         
         for path in notReissuePaths {
-            print("path - \(path), absoluteString - \(urlRequest.url?.absoluteString ?? "nil")")
-            guard urlRequest.url?.absoluteString.contains(path) ?? false else {
+            if urlRequest.url?.absoluteString.contains(path) ?? true {
                 completion(.success(urlRequest))
                 return
             }
         }
-        
         var modifiedRequest = urlRequest
-        print("accessToken - \(accessToken)")
         modifiedRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
         completion(.success(modifiedRequest))
     }

--- a/Projects/App/Source/Data/Network/Remote/RemoteInterceptor.swift
+++ b/Projects/App/Source/Data/Network/Remote/RemoteInterceptor.swift
@@ -11,20 +11,37 @@ import SignKit
 
 class RemoteInterceptor: RequestInterceptor {
     
-    private let maxRetryCount = 3
-    private var retryCount = 0
+    private let notReissuePaths = [
+        "reissue",
+        "login"
+    ]
     
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+        guard let accessToken = Sign.accessToken else {
+            completion(.success(urlRequest))
+            return
+        }
+        
+        for path in notReissuePaths {
+            print("path - \(path), absoluteString - \(urlRequest.url?.absoluteString ?? "nil")")
+            guard urlRequest.url?.absoluteString.contains(path) ?? false else {
+                completion(.success(urlRequest))
+                return
+            }
+        }
+        
+        var modifiedRequest = urlRequest
+        print("accessToken - \(accessToken)")
+        modifiedRequest.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
+        completion(.success(modifiedRequest))
+    }
+
     func retry(
         _ request: Request,
         for session: Session,
         dueTo error: Error,
         completion: @escaping (RetryResult) -> Void
     ) {
-        guard retryCount < maxRetryCount else {
-            completion(.doNotRetryWithError(error))
-            return
-        }
-        
         guard let response = request.task?.response as? HTTPURLResponse else {
             completion(.doNotRetryWithError(error))
             return
@@ -34,6 +51,8 @@ class RemoteInterceptor: RequestInterceptor {
             completion(.doNotRetry)
             return
         }
+        
+        print(response.statusCode)
         
         guard response.statusCode == 401, let refreshToken = Sign.refreshToken else {
             completion(.doNotRetryWithError(error))
@@ -47,10 +66,7 @@ class RemoteInterceptor: RequestInterceptor {
                 try await authRepository.postReissue(
                     .init(refreshToken: refreshToken)
                 )
-                DispatchQueue.main.async {
-                    self.retryCount += 1
-                    completion(.retry)
-                }
+                completion(.retry)
             } catch {
                 if let id = Sign.id,
                    let pw = Sign.password {
@@ -59,7 +75,7 @@ class RemoteInterceptor: RequestInterceptor {
                             .init(id: id, pw: pw)
                         )
                         DispatchQueue.main.async {
-                            self.retryCount += 1
+//                            self.retryCount += 1
                             completion(.retry)
                         }
                     } catch let error {
@@ -68,6 +84,7 @@ class RemoteInterceptor: RequestInterceptor {
                         }
                     }
                 } else {
+                    print("22 \(error)")
                     DispatchQueue.main.async {
                         completion(.doNotRetryWithError(error))
                     }

--- a/Projects/App/Source/Data/Network/Service/Auth/AuthService.swift
+++ b/Projects/App/Source/Data/Network/Service/Auth/AuthService.swift
@@ -45,4 +45,8 @@ extension AuthService {
     var headers: [String: String]? {
         ["Content-Type": "application/json"]
     }
+    
+    var validationType: ValidationType {
+        .none
+    }
 }

--- a/Projects/App/Source/Data/Network/Service/ServiceProtocol.swift
+++ b/Projects/App/Source/Data/Network/Service/ServiceProtocol.swift
@@ -22,11 +22,7 @@ extension ServiceProtocol {
     }
     
     var headers: [String: String]? {
-        var headers = ["Content-Type": "application/json"]
-        if let authorization = Sign.accessToken {
-            headers["Authorization"] = "Bearer \(authorization)"
-        }
-        return headers
+        return ["Content-Type": "application/json"]
     }
     var validationType: ValidationType { .successCodes }
 }


### PR DESCRIPTION
Moya headers에서 토큰 넣는데 이러면 refresh후에 적용이 안돼서 RequestInterceptor.adapt 함수 안에서 토큰 넣었습니다
그리고 auth/reissue, auth/login은 토큰 장착도 하면 안 되고 에러 터져도 다시 reissue할 필요가 없어서 이거 관련해서도 로직 수정 했습니다.